### PR TITLE
fix datetime handling for for Fluent Bit V2

### DIFF
--- a/plugin/util.go
+++ b/plugin/util.go
@@ -67,8 +67,14 @@ func toTime(raw interface{}) time.Time {
 		return typed.Time
 	case uint64:
 		return time.Unix(int64(typed), 0)
+	case []interface{}:
+		if dt, ok := typed[0].(output.FLBTime); ok {
+			return dt.Time
+		}
+		fmt.Printf("provided time (%+v) invalid: defaulting to now.\n", typed)
+		return time.Now()
 	default:
-		fmt.Println("time provided invalid, defaulting to now.")
+		fmt.Printf("provided time (%+v) invalid: defaulting to now.\n", typed)
 		return time.Now()
 	}
 }


### PR DESCRIPTION
in fb v2 the type of datetime get passed to the plugin by go-sdk has been changed (see [corresponding comment](https://github.com/fluent/fluent-bit-go/blob/master/output/decoder.go#L87) in go-sdk sources). the proposed change takes this into account.

otherwise, all the log messages are being parsed incorrectly with annoying 'time provided invalid, defaulting to now.' in the fb log.